### PR TITLE
Handle intervals in package versions

### DIFF
--- a/CycloneDX/CycloneDX.csproj
+++ b/CycloneDX/CycloneDX.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net5.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <PackageId>CycloneDX</PackageId>
+    <PackageId>Devolutions.CycloneDX</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>A .NET Core global tool to generate CycloneDX bill-of-material documents for use with Software Composition Analysis (SCA).</Description>
     <PackAsTool>true</PackAsTool>

--- a/CycloneDX/Program.cs
+++ b/CycloneDX/Program.cs
@@ -283,10 +283,30 @@ namespace CycloneDX {
                     {
                         foreach (var dep in package.Dependencies)
                         {
-                            transitiveDepencies.Add(bomRefLookup[(dep.Key.ToLower(CultureInfo.InvariantCulture), dep.Value.ToLower(CultureInfo.InvariantCulture))]);
+                            string dependencyName = dep.Key.ToLower(CultureInfo.InvariantCulture);
+                            string dependencyVersion = dep.Value.ToLower(CultureInfo.InvariantCulture);
+
+                            if (dependencyVersion.StartsWith("[", StringComparison.InvariantCulture))
+                            {
+                                dependencyVersion = dependencyVersion.Remove(0, 1);
+                                dependencyVersion = dependencyVersion.Split(",")[0];
+                            }
+
+                            if (dependencyVersion.EndsWith("]", StringComparison.InvariantCulture))
+                            {
+                                dependencyVersion = dependencyVersion.Remove(dependencyVersion.Length - 1);
+                            }
+
+                            if (!bomRefLookup.ContainsKey((dependencyName, dependencyVersion)))
+                            {
+                                System.Console.WriteLine($"Warning: Skipping dependency {dependencyName} {dependencyVersion}");
+                                continue;
+                            }
+
+                            transitiveDepencies.Add(bomRefLookup[(dependencyName, dependencyVersion)]);
                             packageDepencies.Dependencies.Add(new Dependency
                             {
-                                Ref = bomRefLookup[(dep.Key.ToLower(CultureInfo.InvariantCulture), dep.Value.ToLower(CultureInfo.InvariantCulture))]
+                                Ref = bomRefLookup[(dependencyName, dependencyVersion)]
                             });
                         }
                     }


### PR DESCRIPTION
This is a quick fix to deal with an exception when package versions of dependencies are defined as intervals, eg. "[AWSSDK.Core] (>= 3.7.10.5 && < 4.0.0)".

Related issue in the cyclonedx-dotnet project:
https://github.com/CycloneDX/cyclonedx-dotnet/issues/518